### PR TITLE
KID discovery: may be pairwise

### DIFF
--- a/draft-ietf-core-oscore-groupcomm.md
+++ b/draft-ietf-core-oscore-groupcomm.md
@@ -1383,7 +1383,7 @@ In order to protect an outgoing message in pairwise mode, the sender needs to kn
 
 Furthermore, the sender needs to know the individual address of the recipient endpoint. This information may not be known at any given point in time. For instance, right after having joined the group, a client may know the authentication credential and Recipient ID for a given server, but not the addressing information required to reach it with an individual, one-to-one request.
 
-To make addressing information of individual endpoints available, servers in the group MAY expose a resource to which a client can send a request targeting a set of servers, identified by their 'kid' values specified in the request payload, or implicitly if the request is sent in pairwise mode. The specified set may be empty, hence identifying all the servers in the group. Further details of such an interface are out of scope for this document.
+To make addressing information of individual endpoints available, servers in the group MAY expose a resource to which a client can send a request targeting a set of servers, identified by their 'kid' values specified in the request payload, or implicitly if the request is sent in pairwise mode. Further details of such an interface are out of scope for this document.
 
 ## Main Differences from OSCORE {#sec-differences-oscore-pairwise}
 

--- a/draft-ietf-core-oscore-groupcomm.md
+++ b/draft-ietf-core-oscore-groupcomm.md
@@ -1383,7 +1383,7 @@ In order to protect an outgoing message in pairwise mode, the sender needs to kn
 
 Furthermore, the sender needs to know the individual address of the recipient endpoint. This information may not be known at any given point in time. For instance, right after having joined the group, a client may know the authentication credential and Recipient ID for a given server, but not the addressing information required to reach it with an individual, one-to-one request.
 
-To make addressing information of individual endpoints available, servers in the group MAY expose a resource to which a client can send a group request targeting a set of servers, identified by their 'kid' values specified in the request payload. The specified set may be empty, hence identifying all the servers in the group. Further details of such an interface are out of scope for this document.
+To make addressing information of individual endpoints available, servers in the group MAY expose a resource to which a client can send a request targeting a set of servers, identified by their 'kid' values specified in the request payload, or implicitly if the request is sent in pairwise mode. The specified set may be empty, hence identifying all the servers in the group. Further details of such an interface are out of scope for this document.
 
 ## Main Differences from OSCORE {#sec-differences-oscore-pairwise}
 


### PR DESCRIPTION
Quoting a review that's being written:

> * 9 / 9.1, " a sender can use the pairwise mode to protect a message
  sent to (but not intended for) multiple recipients": This refers to
  the service roughly outlined in 9.1, but 9.1 describes "a resource to
  which a client can send a group request".

This proposes a fix, and makes up for the added text by removing a sentence.